### PR TITLE
Fixed issue where whitespace will be present if there's no title or message on Android

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -6,8 +6,14 @@ exports.show = function (options) {
         try {
             if (options) {
                 var alert = new android.app.AlertDialog.Builder(application.android.currentContext);
-                alert.setTitle(options.title || "");
-                alert.setMessage(options.message || "");
+
+                if (options.message) {
+                  alert.setMessage(options.message);
+                }
+
+                if (options.title) {
+                  alert.setTitle(options.title);
+                }
 
                 if (options.nativeView instanceof android.view.View) {
                     alert.setView(options.nativeView);


### PR DESCRIPTION
fixes: https://github.com/enchev/nativescript-dialog/issues/4
