### PR TITLE
Set SDCAlertView version to 4.0.1

### DIFF
--- a/platforms/ios/Podfile
+++ b/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'SDCAlertView'
+pod 'SDCAlertView', '~> 4.0.1' 


### PR DESCRIPTION
The latest version of SDCAlertView can't be built with older versions of Xcode because older versions can't compile Swift 2.2 code. Set version 4.0.1 in which older Xcodes manage the compilation process.

Ping @enchev 
